### PR TITLE
Flip the logic for the not before and not after token validation and …

### DIFF
--- a/builtin/credential/aws-kms/cli.go
+++ b/builtin/credential/aws-kms/cli.go
@@ -21,11 +21,13 @@ func createClientToken(keyid *string) (string, error) {
 	}
 	svc := kms.New(session.New(awsConfig))
 
-	notAfter := time.Now().UTC().Add(10 * time.Minute)
-	notBefore := time.Now().UTC().Add(-10 * time.Minute)
+	var now = time.Now().UTC()
+	notAfter := now.Add(10 * time.Minute)
+	notBefore := now.Add(-10 * time.Minute)
+
 	tok := &token{
-		NotBefore: notAfter,
-		NotAfter:  notBefore,
+		NotBefore: notBefore,
+		NotAfter:  notAfter,
 	}
 	tokJson, err := json.Marshal(tok)
 

--- a/builtin/credential/aws-kms/path_login.go
+++ b/builtin/credential/aws-kms/path_login.go
@@ -79,7 +79,9 @@ func (b *backend) pathLogin(
 	if err != nil {
 		return logical.ErrorResponse("Cannot parse token"), nil
 	}
-	if tok.NotBefore.Before(time.Now().UTC()) || tok.NotAfter.After(time.Now().UTC()) {
+	
+	var now = time.Now().UTC()
+	if now.Before(tok.NotBefore) || now.After(tok.NotAfter) {
 		return logical.ErrorResponse("Token expired/not valid yet"), nil
 	}
 


### PR DESCRIPTION
…update cli to have right mappings

I found a bug when writing a java client to use this backend.
The logic is flipped for evaluation the time window for the token.
